### PR TITLE
Fix Typo Error in Chinese Void Element Page

### DIFF
--- a/files/zh-cn/glossary/void_element/index.md
+++ b/files/zh-cn/glossary/void_element/index.md
@@ -40,7 +40,7 @@ _HTML 中不存在自闭合标签（`<tag />`）。_
 
 [XML](/zh-CN/docs/Glossary/XML)、[XHTML](/zh-CN/docs/Glossary/XHTML) 和 [SVG](/zh-CN/docs/Glossary/SVG) 的空元素则必须使用自闭合标签（例如 `<circle cx="50" cy="50" r="50" />`）。
 
-在 SVG 和 MathML 中，有任何子节点的元素不允许使用子闭合标签。在这种情况下，如果元素的开始标签被标记为自闭合，则该元素不能有结束标签。
+在 SVG 和 MathML 中，有任何子节点的元素不允许使用自闭合标签。在这种情况下，如果元素的开始标签被标记为自闭合，则该元素不能有结束标签。
 
 > **备注：** 如果开始标签中的尾随 `/`（斜杠）字符直接位于未使用引号包裹的属性值之后（两者之间没有空格），则该斜杠字符将成为属性值的一部分，而不是被解析器丢弃。例如，标记 `<img src=http://www.example.com/logo.svg/>` 会导致 `src` 属性的值为 `http://www.example.com/logo.svg/`——这会导致 URL 错误。
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
There is a typo error. It shall be "自闭合元素" not ”子闭合元素".

### Motivation

Because it is a typo error, it may make it confusing for the reader to understand.
